### PR TITLE
Update & fix json library dependency

### DIFF
--- a/libra/libra.sls
+++ b/libra/libra.sls
@@ -179,7 +179,7 @@
     (define (default-make-json data)
         (http:content
             '(("Content-Type" . "application/json; charset=utf-8") ("Connection" . "close"))
-                (scm->json-string data)))
+                (json->string data)))
 
     ;; 判断资源文件
     (define (resource? request)

--- a/package.sc
+++ b/package.sc
@@ -13,6 +13,6 @@
     ("libc" . "0.1.2")
     ("socket" . "0.1.1")
     ("irregex" . "0.9.6")
-    ("json" . "0.5.1")
+    ("json" . "1.5.6")
     ("surfage" . "0.1.0"))
 ("devDependencies"))


### PR DESCRIPTION
Library json@0.5.6 is not avaliable on raven so version used is
updated to the latest release version.
Unknown procedure "scm->json-string" replaced with "json->string".